### PR TITLE
Fix header items' alignment issue

### DIFF
--- a/style.css
+++ b/style.css
@@ -55,12 +55,14 @@ header li {
 #nine-squares img {
     height: 16px;
     width: 16px;
+    vertical-align: middle;
 }
 
 #user-icon img {
     height: 32px;
     width: 32px;
     border-radius: 50%;
+    vertical-align: middle;
 }
 
 /* LOGO */


### PR DESCRIPTION
Hi

Actually, the problem was with vertical-alignment of `img` tags that have been used.
They've been aligned on the baseline of the list.
This problem could get solved by setting `vertical-align` of the images to `middle`.
Another possible trick that could be used, is to set `display` of the containing `li`s to `flex` and use `align-items: center`; but this is not the correct answer to the actual problem.

You can read more about the cause [here](https://stackoverflow.com/questions/18516317/vertically-align-an-image-inside-a-div-with-responsive-height/18516474#18516474)